### PR TITLE
Add documentation to disunaur nft files

### DIFF
--- a/disunaurio_nft/data_extractor.py
+++ b/disunaurio_nft/data_extractor.py
@@ -24,7 +24,18 @@ def main(args=None):
     save_yaml(svgs, data_outpath)
     print(f'Extracted data file saved in: {data_outpath}')
 
-def generate_structured_data(rootpath: str) -> defaultdict(list):
+def generate_structured_data(rootpath: str) -> defaultdict:
+    """
+    Iterate over a folder extracting elements (using extract_elements fucntion)
+    form the files maintaining the hierarchy of the file structure translating to 
+    a defaultdict object
+
+    Args:
+        rootpath (str): path where to extract all elements recursively
+
+    Returns:
+        defaultdict: Dictionary of dictionaries mantaining file structure hierarchy
+    """    
     svgs = defaultdict(list)
     for root, _, files in walk(rootpath):
         if files:
@@ -34,6 +45,21 @@ def generate_structured_data(rootpath: str) -> defaultdict(list):
     return svgs
 
 def extract_elements(filepath: str) -> dict:
+    """
+    Given a filepath, obtain id and d elements form parsed xml tags (<path/>).
+    The 'path' tag looks like this:
+    
+        <path id="color_3" class="cls-4" d="M1435,559c12.61,0.453,27.33,24"/>
+
+        - id : identifier of the tag
+        - d  : SVG vector / drawing
+
+    Args:
+        filepath (str): svg file path
+
+    Returns:
+        dict: dictionary with id as keys and d as values
+    """    
     doc = minidom.parse(filepath)
     path_id = [path.getAttribute('id') for path
                     in doc.getElementsByTagName('path')]
@@ -43,6 +69,13 @@ def extract_elements(filepath: str) -> dict:
     return elements
 
 def save_yaml(svgs: defaultdict, output_path: str) -> None:
+    """
+    Save a defaultdict object as yml file in output directory
+
+    Args:
+        svgs (defaultdict): structured data in dictionary form
+        output_path (str): path where the .yml file is saved
+    """    
     with open(output_path, 'w') as of:
         yaml.dump(svgs, of, default_flow_style=False)
 

--- a/disunaurio_nft/data_extractor.py
+++ b/disunaurio_nft/data_extractor.py
@@ -26,8 +26,8 @@ def main(args=None):
 
 def generate_structured_data(rootpath: str) -> defaultdict:
     """
-    Iterate over a folder extracting elements (using extract_elements fucntion)
-    form the files maintaining the hierarchy of the file structure translating to 
+    Iterate over a folder extracting elements (using extract_elements function)
+    from the files maintaining the hierarchy of the file structure translating to 
     a defaultdict object
 
     Args:
@@ -46,7 +46,7 @@ def generate_structured_data(rootpath: str) -> defaultdict:
 
 def extract_elements(filepath: str) -> dict:
     """
-    Given a filepath, obtain id and d elements form parsed xml tags (<path/>).
+    Given a filepath, obtain id and d elements from parsed xml tags (<path/>).
     The 'path' tag looks like this:
     
         <path id="color_3" class="cls-4" d="M1435,559c12.61,0.453,27.33,24"/>

--- a/disunaurio_nft/disunaur_generator.py
+++ b/disunaurio_nft/disunaur_generator.py
@@ -7,6 +7,17 @@ from .element import Element
 
 
 def generate_drawing(element_list: list, filepath: str) -> Drawing:
+    """
+    Generate a svgwrite Drawing object using a list of element objects
+    and save to a svg file.
+
+    Args:
+        element_list (list): List of element objects
+        filepath (str): Filepaht to save the generated drawing
+
+    Returns:
+        Drawing: svgwrite Drawing object
+    """
     drawing = create_canvas(filepath)
     for element in element_list:
         drawing = draw_svg_element(drawing, element)
@@ -14,6 +25,17 @@ def generate_drawing(element_list: list, filepath: str) -> Drawing:
     return drawing
 
 def draw_svg_element(drawing: Drawing, element: Element)->Drawing:
+    """
+    Add svgwrite Path objects created with an element object to a svgwrite
+    Drawing object.
+
+    Args:
+        drawing (Drawing): svgwrite Drawing object
+        element (Element): element object
+
+    Returns:
+        Drawing: svgwrite Drawing object
+    """
     for continent, color in zip(element.continents, element.continents_colors):
         path = svgwrite.path.Path(id=element.id, fill=rgb(color[0], color[1], color[2]),
                                 d=continent, debug=False)
@@ -26,20 +48,83 @@ def draw_svg_element(drawing: Drawing, element: Element)->Drawing:
     return drawing
 
 def create_canvas(filepath: str) -> Drawing:
+    """
+    Create a baseline svgwrite Drawing object with x by y dimensions and a background.
+
+    Args:
+        filepath (str): file path to allocate the drawing/final svg file
+
+    Returns:
+        Drawing: svgwrite Drawing object
+    """
     drawing = Drawing(filepath, size=('2048', '2048'), profile='full')
     color = random.choices(range(256), k=3)
     background = svgwrite.shapes.Rect(insert=(0, 0), size=(2048, 2048), fill=rgb(color[0], color[1], color[2]), id='background')
     drawing.add(background)
     return drawing
 
-def create_element_list(datafile: dict):
+def generate_baseline_drawing(element_list: list, baseline_data: dict) -> list:
+    """
+    Create an element list of the basline drawing with the baseline extracted data (dictionary)
+    and add it to an element list.
+
+    Args:
+        element_list (list): List of element objects
+        baseline_data (dict): Baseline key form dictionary extracted from .yml file
+
+    Returns:
+        list: List of element objects with new objects added
+    """    
+    element_list.extend(create_element_list(baseline_data))
+    return element_list
+
+def generate_complements(element_list: list, complements_data: dict) -> list:
+    """
+    Create an element list of complements with the complements extracted data (dictionary)
+    and add it to an element list.
+
+    Args:
+        element_list (list): List of element objects
+        complements_data (dict): Complements key from dictionary extracted from .yml file
+
+    Returns:
+        list: List of element objects with new objects added
+    """    
+    for comp_name, complement in  complements_data.items():
+        if random.choice([True, False]) or comp_name == 'eyewear':
+            comp_list = create_element_list(complement)
+            comp = random.choice(comp_list)
+            element_list.append(comp)
+    return element_list
+
+def create_element_list(data: dict) -> list:
+    """
+    Extract porperties from a data dictionary, create one element with this extracted data
+    per each dictionary_key/svg_file.
+
+    Args:
+        data (dict): Dictionary with raw data from a svg file
+
+    Returns:
+        list: List of elements, new elements added
+    """
     elements_list = []
-    for id, d in datafile.items():
+    for id, d in data.items():
         contours, colors, priority = extract_properties(d)
         elements_list.append(Element(id, contours, colors, priority))
     return elements_list
 
 def extract_properties(data:dict) -> tuple:
+    """
+    Extract properties from dictionary to generate a list of contours, a list
+    of continents and an int for priority score.
+
+    Args:
+        data (dict): Dictionary with svg extracted data
+
+    Returns:
+        tuple: Tuple of (contour:list, continents:list, priority:int)
+    """    
     contours, continents = [], []
     for key, d in data.items():
         if 'contour' in key: contours.append(d)
@@ -47,19 +132,7 @@ def extract_properties(data:dict) -> tuple:
     priority = data['priority']
     return contours, continents, priority
 
-def load_yaml_conf_file(filepath:str)->dict:
+def load_yaml_conf_file(filepath:str)->dict:    
     with open(filepath, "r") as f:
         data = yaml.safe_load(f)
     return data
-
-def generate_baseline_drawing(element_list: list, baseline_data: dict) -> list:
-    element_list.extend(create_element_list(baseline_data))
-    return element_list
-
-def generate_complements(element_list: list, complements_data: dict) -> list:
-    for comp_name, complement in  complements_data.items():
-        if random.choice([True, False]) or comp_name == 'eyewear':
-            comp_list = create_element_list(complement)
-            comp = random.choice(comp_list)
-            element_list.append(comp)
-    return element_list

--- a/disunaurio_nft/disunaur_generator.py
+++ b/disunaurio_nft/disunaur_generator.py
@@ -132,7 +132,7 @@ def extract_properties(data:dict) -> tuple:
     priority = data['priority']
     return contours, continents, priority
 
-def load_yaml_conf_file(filepath:str)->dict:    
+def load_yaml_conf_file(filepath:str)->dict:
     with open(filepath, "r") as f:
         data = yaml.safe_load(f)
     return data

--- a/disunaurio_nft/disunaur_generator.py
+++ b/disunaurio_nft/disunaur_generator.py
@@ -99,7 +99,7 @@ def generate_complements(element_list: list, complements_data: dict) -> list:
 
 def create_element_list(data: dict) -> list:
     """
-    Extract porperties from a data dictionary, create one element with this extracted data
+    Extract properties from a data dictionary, create one element with this extracted data
     per each dictionary_key/svg_file.
 
     Args:


### PR DESCRIPTION
Create docstrings to document functions of the two main files (disunaur_generator.py and data_generator.py), re-organize order of the functions to make it clear to read (readable) by placing them from higher level of abstraction to lower. I have also fix some issues and variable names which didn't convince me.