### PR TITLE
Separate library functionality from scripts

### DIFF
--- a/disunaurio_nft/data_extractor.py
+++ b/disunaurio_nft/data_extractor.py
@@ -2,8 +2,7 @@ import argparse
 import sys
 import yaml
 from collections import defaultdict
-from email.policy import default
-from os import path, walk, listdir
+from os import path, walk
 from xml.dom import minidom
 from yaml.representer import Representer
 yaml.add_representer(defaultdict, Representer.represent_dict)

--- a/disunaurio_nft/data_extractor.py
+++ b/disunaurio_nft/data_extractor.py
@@ -1,5 +1,3 @@
-import argparse
-import sys
 import yaml
 from collections import defaultdict
 from os import path, walk
@@ -7,21 +5,6 @@ from xml.dom import minidom
 from yaml.representer import Representer
 yaml.add_representer(defaultdict, Representer.represent_dict)
 
-
-def main(args=None):
-    if args is None:
-        args = sys.argv[1:]
-    args = parse_args(args)
-
-    baseline_path = path.join(args.rootpath, 'baseline')
-    complements_path = path.join(args.rootpath, 'complements')
-    data_outpath = path.join(args.rootpath,'data/data.yml')
-
-    svgs = generate_structured_data(baseline_path)
-    svgs['complements'] = generate_structured_data(complements_path)
-
-    save_yaml(svgs, data_outpath)
-    print(f'Extracted data file saved in: {data_outpath}')
 
 def generate_structured_data(rootpath: str) -> defaultdict:
     """
@@ -77,21 +60,3 @@ def save_yaml(svgs: defaultdict, output_path: str) -> None:
     """    
     with open(output_path, 'w') as of:
         yaml.dump(svgs, of, default_flow_style=False)
-
-def parse_args(args):
-    description = '''
-    Extract svg vector data from svg files stored in baseline and complements folders and create data.yml file in data folder.
-    '''
-    epilog = '''
-            python3 ./disunaurio_nft/data_extractor.py
-    '''
-    parser = argparse.ArgumentParser(
-        description=description,
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-        epilog=epilog
-    )
-    parser.add_argument('--rootpath', default=path.join(path.realpath('.'),'svg_files'), help='')
-    return parser.parse_args(args)
-
-if __name__ == '__main__':
-    main()

--- a/scripts/svg_data_extraction.py
+++ b/scripts/svg_data_extraction.py
@@ -1,7 +1,5 @@
 import argparse
 import sys
-
-from collections import defaultdict
 from os import path
 
 from disunaurio_nft.data_extractor import save_yaml, generate_structured_data

--- a/scripts/svg_data_extraction.py
+++ b/scripts/svg_data_extraction.py
@@ -1,0 +1,41 @@
+import argparse
+import sys
+
+from collections import defaultdict
+from os import path
+
+from disunaurio_nft.data_extractor import save_yaml, generate_structured_data
+
+
+def main(args=None):
+    if args is None:
+        args = sys.argv[1:]
+    args = parse_args(args)
+
+    baseline_path = path.join(args.rootpath, 'baseline')
+    complements_path = path.join(args.rootpath, 'complements')
+    data_outpath = path.join(args.rootpath,'data/data.yml')
+
+    svgs = generate_structured_data(baseline_path)
+    svgs['complements'] = generate_structured_data(complements_path)
+
+    save_yaml(svgs, data_outpath)
+    print(f'Extracted data file saved in: {data_outpath}')
+
+def parse_args(args):
+    description = '''
+    Extract svg vector data from svg files stored in baseline and complements folders and create data.yml file in data folder.
+    '''
+    epilog = '''
+            python3 ./disunaurio_nft/data_extractor.py
+    '''
+    parser = argparse.ArgumentParser(
+        description=description,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        epilog=epilog
+    )
+    parser.add_argument('--rootpath', default=path.join(path.realpath('.'),'svg_files'), help='')
+    return parser.parse_args(args)
+
+if __name__ == '__main__':
+    main()

--- a/scripts/svg_drawings_creation.py
+++ b/scripts/svg_drawings_creation.py
@@ -1,0 +1,52 @@
+from email.policy import default
+import sys
+import argparse
+from os import path
+
+from disunaurio_nft.disunaur_generator import (load_yaml_conf_file,
+                                               generate_baseline_drawing,
+                                               generate_complements, 
+                                               generate_drawing,
+                                               sort_by_priority)
+
+
+def main(args = None):
+    if args is None:
+        args = sys.argv[1:]
+    args = parse_args(args)
+
+    baseline_data = load_yaml_conf_file(args.datapath)['baseline']
+    complements_data = load_yaml_conf_file(args.datapath)['complements']
+
+    for i in range(args.num):
+        output_svg_file = path.join(args.output_path, f'disunaurio#{i}.svg')
+
+        element_list = []
+        element_list = generate_baseline_drawing(element_list, baseline_data)
+        element_list = generate_complements(element_list, complements_data)
+
+        element_list = sort_by_priority(element_list)
+        
+        dwg = generate_drawing(element_list, output_svg_file)
+        dwg.save(output_svg_file, True)
+
+def parse_args(args):
+    description = '''
+    Create auto-generative svg files from yml datapath.
+    '''
+    epilog = '''
+            python3 ./scripts/svg_drawings_creation.py ./svg_files/tests/ --num 20
+    '''
+    parser = argparse.ArgumentParser(
+        description=description,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        epilog=epilog
+    )
+    parser.add_argument('output_path', help='')
+    parser.add_argument('--datapath', default=path.join(path.realpath('.'), 'svg_files/data/data.yml'), 
+                        help='Data yaml file location')
+    parser.add_argument('-n', '--num', type=int, default=10, help='Number of svg files created')
+    return parser.parse_args(args)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
The goal of this PR is separate the core library from the scripts. It has been create a folder for this kind of scripts and actions like generate drawing or generate the yaml file with the vector data has been moved to the `svg_drawings_creation.py` and `svg_data_extraction.py` files. The core library it's composed of functions and object which are imported in the scripts to perform a particular action. MTFBWU :)