### PR TITLE
Add CI badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,8 +6,8 @@ disunaurio_nft
 .. image:: https://img.shields.io/pypi/v/disunaurio_nft.svg
         :target: https://pypi.python.org/pypi/disunaurio_nft
 
-.. image:: https://img.shields.io/travis/0rb3/disunaurio_nft.svg
-        :target: https://travis-ci.com/0rb3/disunaurio_nft
+.. image:: https://github.com/i97orbegozo/disunaurio_nft/actions/workflows/test_pipeline.yml/badge.svg?event=push
+        :target: https://github.com/i97orbegozo/disunaurio_nft/actions
 
 .. image:: https://readthedocs.org/projects/disunaurio-nft/badge/?version=latest
         :target: https://disunaurio-nft.readthedocs.io/en/latest/?version=latest


### PR DESCRIPTION
You like these things and you know it :wink:
https://github.com/i97orbegozo/disunaurio_nft/actions/workflows/test_pipeline.yml/badge.svg

![](https://github.com/i97orbegozo/disunaurio_nft/actions/workflows/test_pipeline.yml/badge.svg)

So the CI status will be shown also in the readme.
This can be parametrized with `/badge.svg?event=push`, as [it says in the docs](https://docs.github.com/es/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge).
In this case, the badge displays the status of workflow runs triggered by the push event